### PR TITLE
Dev stacker

### DIFF
--- a/beautiful-racket-demo/stacker-demo/stacker-extended.rkt
+++ b/beautiful-racket-demo/stacker-demo/stacker-extended.rkt
@@ -1,0 +1,38 @@
+#lang br/quicklang
+
+(define (read-syntax path port)
+  (define args (port->lines port))
+  (define handle-datums (format-datums '(handle ~a) args))
+  (define module-datum `(module stacker-mod stacker-demo/stacker
+                          ,@handle-datums))
+  (datum->syntax #f module-datum))
+(provide read-syntax)
+
+(define-macro (stacker-module-begin HANDLE-EXPR ...)
+  #'(#%module-begin
+     HANDLE-EXPR ...
+     (display (first stack))))
+(provide (rename-out [stacker-module-begin #%module-begin]))
+
+(define stack empty)
+
+(define (pop-stack!)
+  (define arg (first stack))
+  (set! stack (rest stack))
+  arg)
+
+(define (push-stack! arg)
+  (set! stack (cons arg stack)))
+
+(define (handle [arg #f])
+  (cond
+    [(number? arg) (push-stack! arg)]
+    [(or (equal? * arg) (equal? + arg) (equal? - arg) (equal? / arg))
+     ; This will ensure that stacker can be extended to support - and / operations while keeping the RPN notation
+     (define operand2 (pop-stack!))
+     (define operand1 (pop-stack!))
+     (define op-result (arg operand1 operand2)) 
+     (push-stack! op-result)]))
+(provide handle)
+
+(provide + * - /)

--- a/beautiful-racket-demo/stacker-demo/stacker-test-2.rkt
+++ b/beautiful-racket-demo/stacker-demo/stacker-test-2.rkt
@@ -1,0 +1,6 @@
+#lang reader "stacker-extended.rkt"
+3
+4
+-
+5
+-

--- a/beautiful-racket-demo/stacker-demo/stacker-test-3.rkt
+++ b/beautiful-racket-demo/stacker-demo/stacker-test-3.rkt
@@ -1,0 +1,8 @@
+#lang reader "stacker-extended.rkt"
+3
+4
+/
+1
+4
+/
++

--- a/beautiful-racket-demo/stacker-demo/stacker.rkt
+++ b/beautiful-racket-demo/stacker-demo/stacker.rkt
@@ -28,7 +28,10 @@
   (cond
     [(number? arg) (push-stack! arg)]
     [(or (equal? * arg) (equal? + arg))
-     (define op-result (arg (pop-stack!) (pop-stack!))) 
+     ; This will ensure that stacker can be extended to support - and / operations while keeping the RPN notation
+     (define operand2 (pop-stack!))
+     (define operand1 (pop-stack!))
+     (define op-result (arg operand1 operand2)) 
      (push-stack! op-result)]))
 (provide handle)
 


### PR DESCRIPTION
Hello Matthew,

I've slightly changed the handle function from stacker to allow extended operations like - and / while keeping RPN notation. Simply extending the original implementation with - and / was giving incorrect results because of the way the arguments taken from the stack were used when evaluating the current operation.

Also, added an example of extending stacker with - and /. Added two extra tests.

Thanks,
Jean
