### PR TITLE
Fix report-datum w/ eof

### DIFF
--- a/beautiful-racket-lib/br/debug.rkt
+++ b/beautiful-racket-lib/br/debug.rkt
@@ -12,9 +12,11 @@
 (define-macro-cases report-datum
   [(_ STX-EXPR) #`(report-datum STX-EXPR #,(syntax->datum #'STX-EXPR))]
   [(_ STX-EXPR NAME)
-   #'(let ()
-       (eprintf "~a = ~v\n" 'NAME (syntax->datum STX-EXPR))
-       STX-EXPR)])
+   #'(let ([stx STX-EXPR])
+       (eprintf "~a = ~v\n" 'NAME (if (eof-object? stx)
+                                      stx
+                                      (syntax->datum stx)))
+       stx)])
 
 (define-macro (define-multi-version MULTI-NAME NAME)
   #'(define-macro (MULTI-NAME X (... ...))

--- a/beautiful-racket-lib/br/debug.rkt
+++ b/beautiful-racket-lib/br/debug.rkt
@@ -5,14 +5,14 @@
 (define-macro-cases report
   [(_ EXPR) #'(report EXPR EXPR)]
   [(_ EXPR NAME)
-   #'(let ([expr-result EXPR]) 
+   #'(let ([expr-result EXPR])
        (eprintf "~a = ~v\n" 'NAME expr-result)
        expr-result)])
 
 (define-macro-cases report-datum
   [(_ STX-EXPR) #`(report-datum STX-EXPR #,(syntax->datum #'STX-EXPR))]
   [(_ STX-EXPR NAME)
-   #'(let () 
+   #'(let ()
        (eprintf "~a = ~v\n" 'NAME (syntax->datum STX-EXPR))
        STX-EXPR)])
 


### PR DESCRIPTION
Extended report-datum to be friendly to eof.

read-syntax returns either a syntax or eof. This allows report-datum to be used to debug read-syntax issues.