### PR TITLE
improve CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   run:
     name: "Build using Racket '${{ matrix.racket-version }}' (${{ matrix.racket-variant }})"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.xfail == 'yes' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,6 +26,13 @@ jobs:
           - {racket-version: "7.1",    racket-variant: "CS"}
           - {racket-version: "7.2",    racket-variant: "CS"}
           - {racket-version: "7.3",    racket-variant: "CS"}
+        include:
+          - {racket-version: "6.7",     racket-variant: "BC", xfail: "yes"}
+          - {racket-version: "7.7",     racket-variant: "CS", xfail: "yes"}
+          - {racket-version: "7.8",     racket-variant: "CS", xfail: "yes"}
+          - {racket-version: "7.9",     racket-variant: "CS", xfail: "yes"}
+          - {racket-version: "current", racket-variant: "BC", xfail: "yes"}
+          - {racket-version: "current", racket-variant: "CS", xfail: "yes"}
     env:
       DISPLAY: :99
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           - {racket-version: "7.1",    racket-variant: "CS"}
           - {racket-version: "7.2",    racket-variant: "CS"}
           - {racket-version: "7.3",    racket-variant: "CS"}
+    env:
+      DISPLAY: :99
 
     steps:
     - name: Checkout
@@ -49,12 +51,14 @@ jobs:
     - name: install br
       run: raco pkg install --deps search-auto https://github.com/mbutterick/beautiful-racket.git?path=beautiful-racket
 
-    - name: Run the brm tests
-      run: xvfb-run raco test -p beautiful-racket-macro
-    - name: Run the lib tests
-      run: xvfb-run raco test -p beautiful-racket-lib
-    - name: Run the demo tests
-      run: xvfb-run raco test -p beautiful-racket-demo
-    - name: Run the br tests
-      run: xvfb-run raco test -p beautiful-racket
+    - name: Start virtual framebuffer
+      run: Xvfb "$DISPLAY" -screen 0 1280x1024x24 &
 
+    - name: Run the brm tests
+      run: raco test -p beautiful-racket-macro
+    - name: Run the lib tests
+      run: raco test -p beautiful-racket-lib
+    - name: Run the demo tests
+      run: raco test -p beautiful-racket-demo
+    - name: Run the br tests
+      run: raco test -p beautiful-racket

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        racket-version: ["6.7", "6.8", "6.9", "6.11", "6.12", "7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6", "7.7", "7.8", "7.9", "current"]
+        racket-version: ["6.7", "6.8", "6.9", "6.11", "6.12", "7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6", "7.7", "7.8", "7.9", "8.0", "8.1", "current"]
         racket-variant: ["BC", "CS"]
         # CS builds are only provided for versions 7.4 and up so avoid
         # running the job for prior versions.


### PR DESCRIPTION
I finally had a bit of time to look into bogdanp/setup-racket#29. 

It looks like there were two issues here:

1) Sometimes `xvfb-run` doesn't relinquish the display port in time, which leads to `xvfb-run: error: Xvfb failed to start` errors. This is fixed in 3dc7aa3 by only starting a single framebuffer for all tests.

2) The tests are `SIGABRT`ed on 6.7BC, 7.{7,8,9}CS. I think this is a genuine issue with those versions of Racket, because, across many runs ([1](https://github.com/Bogdanp/beautiful-racket/actions/runs/823468578), [2](https://github.com/Bogdanp/beautiful-racket/actions/runs/823483250), [3](https://github.com/Bogdanp/beautiful-racket/actions/runs/823494290)), it's always those versions that fail. The fix here is to allow failures on those versions.